### PR TITLE
Fix missing SVM block tagging

### DIFF
--- a/titanic-ml-dataset/titanic_dataset_ml.ipynb
+++ b/titanic-ml-dataset/titanic_dataset_ml.ipynb
@@ -1533,7 +1533,12 @@
   {
    "cell_type": "code",
    "execution_count": 32,
-   "metadata": {},
+   "metadata": {
+    "tags": [
+     "block:svm",
+     "prev:featureengineering"
+    ]
+   },
    "outputs": [],
    "source": [
     "linear_svc = SVC(gamma='auto')\n",


### PR DESCRIPTION
The commit kubeflow-kale/examples@1281e06c5754ec598823e268a4eed3a3427738c7 deleted SVM block's tags, rendering the notebook broken.